### PR TITLE
docs: Add initial planning for React integration

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,61 @@
+# Technical Plan for React Integration
+
+This document outlines the technical plan for integrating the OpenSim visualization into a new React application.
+
+## 1. Setting Up the React Project
+
+*   **Technology Stack:**
+    *   **React:** The core of our new frontend application.
+    *   **TypeScript:** For type safety and improved developer experience.
+    *   **Vite:** As the build tool for a fast development experience.
+    *   **Zustand or Redux Toolkit:** For state management, particularly for managing the state of the 3D scene and user interactions.
+*   **Project Structure:**
+    *   A new `react-app` directory will be created in the root of the repository to house the new React application.
+    *   The existing `Gui/opensim/threejs` directory will be kept for reference during the initial development phase but will eventually be removed.
+
+## 2. Creating the Three.js Canvas Component
+
+*   A dedicated React component, `ThreeCanvas`, will be created to encapsulate the Three.js rendering logic.
+*   This component will be responsible for:
+    *   Initializing the Three.js `WebGLRenderer`, `Scene`, and `Camera`.
+    *   Handling the rendering loop using `requestAnimationFrame`.
+    *   Managing the resizing of the canvas to fit its container.
+*   We will use the `react-three-fiber` library to simplify the integration of Three.js with React. This will allow us to create and manage Three.js objects declaratively within our React components.
+
+## 3. Communication with the Jetty Server
+
+*   The existing communication between the frontend and the Jetty server is based on a WebSocket connection and REST API calls. We need to replicate this in our React application.
+*   **WebSocket Connection:**
+    *   A WebSocket connection will be established to receive real-time updates from the server, such as new models, animations, or changes in the scene.
+    *   A dedicated service or hook will be created to manage the WebSocket connection and handle incoming messages.
+*   **REST API Calls:**
+    *   The existing REST API will be used to load initial model data and perform other actions.
+    *   We will use a library like `axios` to make these API calls.
+
+## 4. State Management
+
+*   The state of the 3D scene, including the loaded models, their positions, and animations, will be managed using a state management library (e.g., Zustand or Redux Toolkit).
+*   This will allow different components in the application to access and modify the scene state in a predictable way.
+
+## 5. Replacing the Existing Web Application
+
+*   Once the new React application has reached a sufficient level of maturity, we will switch the Jetty server to serve the new application instead of the old one.
+*   This will involve:
+    *   Building the React application for production.
+    *   Configuring the Jetty server to serve the `index.html` file from the `react-app/dist` directory.
+    *   Updating the Java code that launches the `JxBrowser` instance to point to the correct URL for the new application.
+
+## 6. Development Workflow
+
+1.  **Phase 1: Basic Setup**
+    *   Set up the React project with Vite and TypeScript.
+    *   Create the basic `ThreeCanvas` component.
+    *   Render a simple Three.js scene with a cube to verify the setup.
+2.  **Phase 2: Server Communication**
+    *   Implement the WebSocket and REST API communication logic.
+    *   Load a simple model from the Jetty server and display it in the `ThreeCanvas` component.
+3.  **Phase 3: Feature Parity**
+    *   Implement the full functionality of the existing visualizer, including model loading, animation controls, and user interactions.
+4.  **Phase 4: Integration and Replacement**
+    *   Integrate the React application with the Jetty server.
+    *   Remove the old `Gui/opensim/threejs` directory.

--- a/README.md
+++ b/README.md
@@ -1,116 +1,21 @@
-<!-- OpenSim Logo -->
-<p align=center>
-    <a href="https://opensim.stanford.edu/">
-        <img src="https://drive.google.com/uc?id=1urYfucgR4pCM5OeXySMBVc3i5oGfYRAf" alt="OpenSim Logo">
-</p>
+# OpenSim GUI Fork for React Integration
 
-<!-- Badges -->
-<p align=center>
-    <a href="https://github.com/opensim-org/opensim-gui/actions">
-        <img src="https://github.com/opensim-org/opensim-gui/actions/workflows/continuous-integration.yml/badge.svg" alt="Continuous Integration Badge">
-    </a>
-    <a href="https://github.com/opensim-org/opensim-gui/releases">
-        <img src="https://img.shields.io/github/v/release/opensim-org/opensim-gui?include_prereleases" alt="Releases Badge">
-    </a>
-    <a href="https://github.com/opensim-org/opensim-gui/blob/master/LICENSE.txt">
-        <img src="https://img.shields.io/hexpm/l/apa" alt="License Badge">
-    </a>
-    <a href="https://github.com/opensim-org/opensim-gui/wiki/Build-Instructions">
-        <img src="https://img.shields.io/badge/platform-windows%20%7C%20macos%20%7C%20linux-lightgrey" alt="Supported Platforms Badge">
-    </a>
-    <a href="https://github.com/opensim-org/opensim-gui/graphs/contributors">
-        <img src="https://img.shields.io/github/contributors/opensim-org/opensim-gui" alt="ZenHub Badge">
-    </a>
-    <a href="https://zenhub.com">
-        <img src="https://img.shields.io/badge/Shipping%20faster%20with-ZenHub-blueviolet" alt="ZenHub Badge">
-    </a>
-</p>
+This is a fork of the [OpenSim GUI](https://github.com/opensim-org/opensim-gui) project. The goal of this fork is to extract the visualization components and integrate them into a modern React-based web application. This will not be contributed back to the upstream project.
 
----
+## Architecture Overview
 
-**NOTE: This repository contains the source code of OpenSim Java GUI 4.x and cannot be used to build OpenSim 3.x or earlier.**
+The original OpenSim GUI uses a Java-based backend and a web-based frontend for its visualization. Here's a breakdown of the key components:
 
-OpenSim is software that lets users develop models of musculoskeletal structures and create dynamic simulations of movement.
+*   **Jetty Web Server:** A Java-based web server is used to host the visualization frontend and serve 3D model data. This is located in the `opensim-visualizer` directory.
+*   **Three.js Frontend:** The client-side application is built using [Three.js](https://threejs.org/), a popular JavaScript library for 3D graphics. The source code for this application is located in the `Gui/opensim/threejs` directory.
+*   **JxBrowser:** The Java application uses an embedded browser called JxBrowser to display the Three.js frontend.
 
-More information can be found at our websites:
-* [OpenSim website](http://opensim.stanford.edu), in particular the [support page](http://opensim.stanford.edu/support/index.html).
-* [SimTK project website](https://simtk.org/home/opensim).
+## Plan for React Integration
 
-This repository does *not* include source code for the OpenSim core API. The source code for the OpenSim core API can be found [here](https://github.com/opensim-org/opensim-core).
+The plan is to replace the existing Three.js frontend with a new React application. This will involve:
 
-## Download and Setup
+1.  Setting up a new React project.
+2.  Creating a React component to host the Three.js canvas.
+3.  Replicating the existing communication logic between the frontend and the Jetty server to load and control the 3D models.
 
-You can download OpenSim GUI from the simtk website:
-
-- **OpenSim GUI**
-  - [Download page](https://simtk.org/frs/?group_id=91)
-  - [Scripting in the GUI](https://simtk-confluence.stanford.edu/display/OpenSim/Scripting+in+the+GUI)
-- **Looking for help?**
-  - [Ask a question](https://simtk.org/plugins/phpBB/indexPhpbb.php?group_id=91&pluginname=phpBB)
-  - [Submit an Issue](https://github.com/opensim-org/opensim-core/issues)
-
-## Documentation
-
-OpenSim's documentation can be found in our [Documentation](https://simtk-confluence.stanford.edu/display/OpenSim/Documentation) website.
-
-Examples and Tutorials for OpenSim can be found in the [Examples and tutorials](https://simtk-confluence.stanford.edu/display/OpenSim/Examples+and+Tutorials) website. These tutorials move from introductory to more advanced, so you can learn OpenSim in a progressive way. Additional OpenSim-based tutorials, homework problems, and project ideas are available on the [Biomechanics of Movement classroom site](https://simtk-confluence-homeworks.stanford.edu/pages/viewpage.action?pageId=5537857). 
-
-## Releases [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/opensim-org/opensim-gui?include_prereleases)](https://github.com/opensim-org/opensim-gui/releases)
-
-This repository contains releases for OpenSim GUI 4.x. You can find all of the OpenSim's releases in the [Releases](https://github.com/opensim-org/opensim-gui/releases) page of this repository.
-
-## Build instructions [![platforms](https://img.shields.io/badge/platform-windows%20%7C%20macos%20%7C%20linux-lightgrey)](https://github.com/opensim-org/opensim-gui/wiki/Build-Instructions)
-
-We provide scripts to build OpenSim on Windows, macOS and Linux (Ubuntu and Debian). The instructions to download and execute the scripts can be found in the [Build Instructions](https://github.com/opensim-org/opensim-gui/wiki/Build-Instructions) page of this repository's wiki.
-
-### Disclaimer
-
-Due to the small development team working on the GUI, we do not provide support for building or altering the OpenSim GUI source code. The provided build instructions may get out of date occasionally. The defacto instructions are those included/used by the [Continuous Integration (CI) build scripts](https://github.com/opensim-org/opensim-gui/blob/master/.github/workflows/continuous-integration.yml). See the [OpenSim Confluence Wiki](https://simtk-confluence.stanford.edu/display/OpenSim40/Building+OpenSim+from+Source) for additional information.
-
-
-## Contribute [![GitHub contributors](https://img.shields.io/github/contributors/opensim-org/opensim-gui)](https://github.com/opensim-org/opensim-gui/graphs/contributors)
-
-There are many ways in which you can participate in this project. For example:
-
- - Report bugs and request features by submitting a [GitHub Issue](https://github.com/opensim-org/opensim-gui/issues).
- - Ask and answer questions on our [Forum](https://simtk.org/plugins/phpBB/indexPhpbb.php?group_id=91&pluginname=phpBB).
- - Review and test new [Pull Requests](https://github.com/opensim-org/opensim-gui/pulls).
- - Review the [Documentation](https://simtk-confluence.stanford.edu:8443/display/OpenSim/Documentation) and the [Wiki](https://github.com/opensim-org/opensim-gui/wiki) by reporting typos, confusing explanations and adding/suggesting new content.
- - Fix bugs and contribute to OpenSim GUI's source code by creating a [Pull Requests](https://github.com/opensim-org/opensim-gui/pulls).
-
-Please, read our [Developer's guide](https://simtk-confluence.stanford.edu:8443/display/OpenSim/Developer%27s+Guide), [Developer's Guidelines] and our [Code of Conduct](https://github.com/opensim-org/opensim-core/blob/master/CODE_OF_CONDUCT.md) before making a pull request. 
-
-
-## License [![License](https://img.shields.io/hexpm/l/apa)](https://github.com/opensim-org/opensim-gui/blob/master/LICENSE.txt)
-
-Licensed under the Apache License, Version 2.0.  See the full text of the [Apache License, Version 2.0](https://github.com/opensim-org/opensim-gui/blob/master/LICENSE.txt) for more information. This license makes OpenSim suitable for commercial, government, academic, and personal use. 
-
-Third-party components have their own licenses. see our [Notice](https://github.com/opensim-org/opensim-gui/blob/master/NOTICE.txt), and [Acknowledgements](https://simtk-confluence.stanford.edu:8443/display/OpenSim/Acknowledgements) webpages for more information.
-
-The OpenSim GUI's visualizer uses [JxBrowser](https://www.teamdev.com/jxbrowser), which is proprietary software. The use of JxBrowser is governed by [JxBrowser Product Licence Agreement](http://www.teamdev.com/jxbrowser-licence-agreement). If you would like to use JxBrowser in your development, please contact [TeamDev](https://www.teamdev.com/contact/).
-
-### How to acknowledge us
-
-Acknowledging the OpenSim project helps us and helps you. It allows us to track our impact, which is essential for securing funding to improve the software and provide support to our users (you). If you use OpenSim, we would be extremely grateful if you acknowledge us by citing the following paper:
-
-> Seth A, Hicks JL, Uchida TK, Habib A, Dembia CL, et al. (2018) **OpenSim: Simulating musculoskeletal dynamics and neuromuscular control to study human and animal movement.** _PLOS Computational Biology_ 14(7): e1006223. https://doi.org/10.1371/journal.pcbi.1006223
-
-If you use plugins, models, or other components contributed by your fellow researchers, you must acknowledge their work as described in the license that accompanies each of these files.
-
-
-## Funding
-
-The OpenSim project is currently supported by the following:
- - United States National Institutes of Health (NIH)
-    - [Mobilize Center](https://mobilize.stanford.edu/) (P41 EB027060)
-    - [Restore Center](https://restore.stanford.edu/) (P2C HD101913)
- - [Wu Tsai Human Performance Alliance](https://humanperformancealliance.org/)
-
-Past funding includes the following grants and contracts:
-
- - United States National Institutes of Health (NIH)
-    - Simulation of Biological Structures (Simbios; U54 GM072970)
-    - Simulation in Rehabilitation Research (NCSRR; R24 HD065690, P2C HD065690)
-    - Mobilize Center (U54 EB020405)
- - United States Defense Advanced Research Projects Agency (DARPA)
-    - Warrior Web (W911QX-12-C-0018)
+For more detailed technical information, please refer to the `PLAN.md` file.

--- a/README.original.md
+++ b/README.original.md
@@ -1,0 +1,116 @@
+<!-- OpenSim Logo -->
+<p align=center>
+    <a href="https://opensim.stanford.edu/">
+        <img src="https://drive.google.com/uc?id=1urYfucgR4pCM5OeXySMBVc3i5oGfYRAf" alt="OpenSim Logo">
+</p>
+
+<!-- Badges -->
+<p align=center>
+    <a href="https://github.com/opensim-org/opensim-gui/actions">
+        <img src="https://github.com/opensim-org/opensim-gui/actions/workflows/continuous-integration.yml/badge.svg" alt="Continuous Integration Badge">
+    </a>
+    <a href="https://github.com/opensim-org/opensim-gui/releases">
+        <img src="https://img.shields.io/github/v/release/opensim-org/opensim-gui?include_prereleases" alt="Releases Badge">
+    </a>
+    <a href="https://github.com/opensim-org/opensim-gui/blob/master/LICENSE.txt">
+        <img src="https://img.shields.io/hexpm/l/apa" alt="License Badge">
+    </a>
+    <a href="https://github.com/opensim-org/opensim-gui/wiki/Build-Instructions">
+        <img src="https://img.shields.io/badge/platform-windows%20%7C%20macos%20%7C%20linux-lightgrey" alt="Supported Platforms Badge">
+    </a>
+    <a href="https://github.com/opensim-org/opensim-gui/graphs/contributors">
+        <img src="https://img.shields.io/github/contributors/opensim-org/opensim-gui" alt="ZenHub Badge">
+    </a>
+    <a href="https://zenhub.com">
+        <img src="https://img.shields.io/badge/Shipping%20faster%20with-ZenHub-blueviolet" alt="ZenHub Badge">
+    </a>
+</p>
+
+---
+
+**NOTE: This repository contains the source code of OpenSim Java GUI 4.x and cannot be used to build OpenSim 3.x or earlier.**
+
+OpenSim is software that lets users develop models of musculoskeletal structures and create dynamic simulations of movement.
+
+More information can be found at our websites:
+* [OpenSim website](http://opensim.stanford.edu), in particular the [support page](http://opensim.stanford.edu/support/index.html).
+* [SimTK project website](https://simtk.org/home/opensim).
+
+This repository does *not* include source code for the OpenSim core API. The source code for the OpenSim core API can be found [here](https://github.com/opensim-org/opensim-core).
+
+## Download and Setup
+
+You can download OpenSim GUI from the simtk website:
+
+- **OpenSim GUI**
+  - [Download page](https://simtk.org/frs/?group_id=91)
+  - [Scripting in the GUI](https://simtk-confluence.stanford.edu/display/OpenSim/Scripting+in+the+GUI)
+- **Looking for help?**
+  - [Ask a question](https://simtk.org/plugins/phpBB/indexPhpbb.php?group_id=91&pluginname=phpBB)
+  - [Submit an Issue](https://github.com/opensim-org/opensim-core/issues)
+
+## Documentation
+
+OpenSim's documentation can be found in our [Documentation](https://simtk-confluence.stanford.edu/display/OpenSim/Documentation) website.
+
+Examples and Tutorials for OpenSim can be found in the [Examples and tutorials](https://simtk-confluence.stanford.edu/display/OpenSim/Examples+and+Tutorials) website. These tutorials move from introductory to more advanced, so you can learn OpenSim in a progressive way. Additional OpenSim-based tutorials, homework problems, and project ideas are available on the [Biomechanics of Movement classroom site](https://simtk-confluence-homeworks.stanford.edu/pages/viewpage.action?pageId=5537857).
+
+## Releases [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/opensim-org/opensim-gui?include_prereleases)](https://github.com/opensim-org/opensim-gui/releases)
+
+This repository contains releases for OpenSim GUI 4.x. You can find all of the OpenSim's releases in the [Releases](https://github.com/opensim-org/opensim-gui/releases) page of this repository.
+
+## Build instructions [![platforms](https://img.shields.io/badge/platform-windows%20%7C%20macos%20%7C%20linux-lightgrey)](https://github.com/opensim-org/opensim-gui/wiki/Build-Instructions)
+
+We provide scripts to build OpenSim on Windows, macOS and Linux (Ubuntu and Debian). The instructions to download and execute the scripts can be found in the [Build Instructions](https://github.com/opensim-org/opensim-gui/wiki/Build-Instructions) page of this repository's wiki.
+
+### Disclaimer
+
+Due to the small development team working on the GUI, we do not provide support for building or altering the OpenSim GUI source code. The provided build instructions may get out of date occasionally. The defacto instructions are those included/used by the [Continuous Integration (CI) build scripts](https://github.com/opensim-org/opensim-gui/blob/master/.github/workflows/continuous-integration.yml). See the [OpenSim Confluence Wiki](https://simtk-confluence.stanford.edu/display/OpenSim40/Building+OpenSim+from+Source) for additional information.
+
+
+## Contribute [![GitHub contributors](https://img.shields.io/github/contributors/opensim-org/opensim-gui)](https://github.com/opensim-org/opensim-gui/graphs/contributors)
+
+There are many ways in which you can participate in this project. For example:
+
+ - Report bugs and request features by submitting a [GitHub Issue](https://github.com/opensim-org/opensim-gui/issues).
+ - Ask and answer questions on our [Forum](https://simtk.org/plugins/phpBB/indexPhpbb.php?group_id=91&pluginname=phpBB).
+ - Review and test new [Pull Requests](https://github.com/opensim-org/opensim-gui/pulls).
+ - Review the [Documentation](https://simtk-confluence.stanford.edu:8443/display/OpenSim/Documentation) and the [Wiki](https://github.com/opensim-org/opensim-gui/wiki) by reporting typos, confusing explanations and adding/suggesting new content.
+ - Fix bugs and contribute to OpenSim GUI's source code by creating a [Pull Requests](https://github.com/opensim-org/opensim-gui/pulls).
+
+Please, read our [Developer's guide](https://simtk-confluence.stanford.edu:8443/display/OpenSim/Developer%27s+Guide), [Developer's Guidelines] and our [Code of Conduct](https://github.com/opensim-org/opensim-core/blob/master/CODE_OF_CONDUCT.md) before making a pull request.
+
+
+## License [![License](https://img.shields.io/hexpm/l/apa)](https://github.com/opensim-org/opensim-gui/blob/master/LICENSE.txt)
+
+Licensed under the Apache License, Version 2.0.  See the full text of the [Apache License, Version 2.0](https://github.com/opensim-org/opensim-gui/blob/master/LICENSE.txt) for more information. This license makes OpenSim suitable for commercial, government, academic, and personal use.
+
+Third-party components have their own licenses. see our [Notice](https://github.com/opensim-org/opensim-gui/blob/master/NOTICE.txt), and [Acknowledgements](https://simtk-confluence.stanford.edu:8443/display/OpenSim/Acknowledgements) webpages for more information.
+
+The OpenSim GUI's visualizer uses [JxBrowser](https://www.teamdev.com/jxbrowser), which is proprietary software. The use of JxBrowser is governed by [JxBrowser Product Licence Agreement](http://www.teamdev.com/jxbrowser-licence-agreement). If you would like to use JxBrowser in your development, please contact [TeamDev](https://www.teamdev.com/contact/).
+
+### How to acknowledge us
+
+Acknowledging the OpenSim project helps us and helps you. It allows us to track our impact, which is essential for securing funding to improve the software and provide support to our users (you). If you use OpenSim, we would be extremely grateful if you acknowledge us by citing the following paper:
+
+> Seth A, Hicks JL, Uchida TK, Habib A, Dembia CL, et al. (2018) **OpenSim: Simulating musculoskeletal dynamics and neuromuscular control to study human and animal movement.** _PLOS Computational Biology_ 14(7): e1006223. https://doi.org/10.1371/journal.pcbi.1006223
+
+If you use plugins, models, or other components contributed by your fellow researchers, you must acknowledge their work as described in the license that accompanies each of these files.
+
+
+## Funding
+
+The OpenSim project is currently supported by the following:
+ - United States National Institutes of Health (NIH)
+    - [Mobilize Center](https://mobilize.stanford.edu/) (P41 EB027060)
+    - [Restore Center](https://restore.stanford.edu/) (P2C HD101913)
+ - [Wu Tsai Human Performance Alliance](https://humanperformancealliance.org/)
+
+Past funding includes the following grants and contracts:
+
+ - United States National Institutes of Health (NIH)
+    - Simulation of Biological Structures (Simbios; U54 GM072970)
+    - Simulation in Rehabilitation Research (NCSRR; R24 HD065690, P2C HD065690)
+    - Mobilize Center (U54 EB020405)
+ - United States Defense Advanced Research Projects Agency (DARPA)
+    - Warrior Web (W911QX-12-C-0018)


### PR DESCRIPTION
This commit introduces the initial documentation and planning for migrating the OpenSim GUI frontend to a React-based application.

- The original README.md has been backed up to README.original.md.
- A new README.md has been created to reflect the new goals of this fork.
- A PLAN.md file has been added, outlining the technical strategy for the React integration.

Fixes issue #<issue_number>

### Brief summary of changes

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
