### PR TITLE
Modernize plan and scaffold lightweight React visualizer

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,109 +1,80 @@
-# Technical Plan for React Integration
+# React Visualization Integration Plan
 
-This document outlines the technical plan for integrating the OpenSim visualization into a new React application.
+This plan describes how the OpenSim visualization pieces will be ported into the Vite/React application that lives in `light-weight/`. It focuses on a modern, modular build while keeping the communication and data-flow contracts from the original OpenSim GUI.
 
-## 1. React Project Setup
+## 1. Project Goals
 
-*   **Technology Stack:**
-    *   **React:** The core of our new frontend application.
-    *   **TypeScript:** For type safety and improved developer experience.
-    *   **Vite:** As the build tool for a fast development experience.
-    *   **Zustand or Redux Toolkit:** For state management, particularly for managing the state of the 3D scene and user interactions.
-*   **Project Structure:**
-    *   The new React application is located in the `light-weight` directory. It is set up using Vite and TypeScript.
-    *   The existing `Gui/opensim/threejs` directory will be kept for reference during the initial development phase but will eventually be removed.
+* Extract the reusable visualization pieces from the existing OpenSim GUI and surface them inside a standalone React application.
+* Mirror the original client/server data flow so the React app can drive the OpenSim backend without rewriting core simulation logic.
+* Keep the new frontend lightweight, testable, and easy to iterate on.
 
-## 2. Creating the Three.js Canvas Component
-
-*   A dedicated React component, `ThreeCanvas`, will be created to encapsulate the Three.js rendering logic.
-*   This component will be responsible for:
-    *   Initializing the Three.js `WebGLRenderer`, `Scene`, and `Camera`.
-    *   Handling the rendering loop using `requestAnimationFrame`.
-    *   Managing the resizing of the canvas to fit its container.
-*   We will use the `react-three-fiber` library to simplify the integration of Three.js with React. This will allow us to create and manage Three.js objects declaratively within our React components.
-
-## 3. Communication with the Jetty Server
-
-*   The existing communication between the frontend and the Jetty server is based on a WebSocket connection and REST API calls. We need to replicate this in our React application.
-*   **WebSocket Connection:**
-    *   A WebSocket connection will be established to receive real-time updates from the server, such as new models, animations, or changes in the scene.
-    *   A dedicated service or hook will be created to manage the WebSocket connection and handle incoming messages.
-*   **REST API Calls:**
-    *   The existing REST API will be used to load initial model data and perform other actions.
-    *   We will use a library like `axios` to make these API calls.
-
-## 4. State Management
-
-*   The state of the 3D scene, including the loaded models, their positions, and animations, will be managed using a state management library (e.g., Zustand or Redux Toolkit).
-*   This will allow different components in the application to access and modify the scene state in a predictable way.
-
-## 5. Replacing the Existing Web Application
-
-*   Once the new React application has reached a sufficient level of maturity, we will switch the Jetty server to serve the new application instead of the old one.
-*   This will involve:
-    *   Building the React application for production.
-    *   Configuring the Jetty server to serve the `index.html` file from the `react-app/dist` directory.
-    *   Updating the Java code that launches the `JxBrowser` instance to point to the correct URL for the new application.
-
-## 6. Original Architecture and Data Flow
-
-The original OpenSim GUI visualization is composed of a Java-based backend and a JavaScript-based frontend. They communicate primarily through a WebSocket connection.
-
-### Backend (opensim-visualizer)
-
-*   **Jetty Server:** A lightweight, embeddable Java web server.
-    *   `JettyMain.java`: Initializes the server on port 8001. It serves the static frontend files located in `Gui/opensim/threejs/editor/` and sets up a WebSocket endpoint at `/visEndpoint`.
-*   **WebSocket Handling:**
-    *   `OpenSimSocketServlet.java`: A servlet that registers `VisWebSocket` as the handler for incoming WebSocket connections.
-    *   `VisWebSocket.java`: Manages the lifecycle of a WebSocket connection. It receives JSON messages from the client, parses them, and notifies the backend of user actions. It also sends messages from the backend to the client to update the visualization.
-    *   `WebSocketDB.java`: A singleton that maintains a collection of all active `VisWebSocket` instances. This allows the backend to broadcast messages to all connected clients.
-
-### Frontend (Gui/opensim/threejs/editor)
-
-*   **Three.js Application:** A client-side application that renders the 3D scene.
-    *   `index.html`: The main entry point of the application. It loads all the necessary JavaScript libraries, including Three.js, and the application-specific code.
-    *   `websocket.js`: Establishes and manages the WebSocket connection to the server. It listens for incoming messages and triggers actions in the frontend based on the `Op` (operation) field in the JSON payload.
-    *   `OpenSimEditor.js`: The core of the frontend application. It manages the Three.js scene, objects, and user interactions. The `websocket.js` script calls methods on the global `editor` object to manipulate the scene.
-
-### Data Flow Diagram
+## 2. Repository Layout
 
 ```
-+---------------------------------+      WebSocket (JSON)      +--------------------------------+
-|         Backend (Java)          | <------------------------> |      Frontend (Three.js)       |
-|                                 |                            |                                |
-|  +---------------------------+  |                            |  +--------------------------+  |
-|  |       OpenSim Core        |  |                            |  |       OpenSimEditor      |  |
-|  +---------------------------+  |                            |  +--------------------------+  |
-|               |               |                            |               ^              |
-|               v               |                            |               |              |
-|  +---------------------------+  |                            |  +--------------------------+  |
-|  |     WebSocketDB/Server    |  |                            |  |       websocket.js       |  |
-|  +---------------------------+  |                            |  +--------------------------+  |
-|                                 |                            |                                |
-+---------------------------------+                            +--------------------------------+
+opensim-gui-light-weight/
+├── opensim-visualizer/   # Original Jetty + WebSocket backend (reference and runtime)
+├── Gui/opensim/threejs/  # Legacy frontend (reference only)
+└── light-weight/         # Vite/React implementation
 ```
 
-### Communication Protocol
+All new UI work happens inside `light-weight/`. The legacy frontend remains in the repo for reference while parity is being built.
 
-*   The communication between the backend and frontend is based on JSON messages sent over the WebSocket.
-*   Each message contains an `Op` field that specifies the action to be performed.
-*   Examples of operations include:
-    *   `OpenModel`: Loads a new 3D model.
-    *   `Frame`: Updates the position and orientation of objects in the scene for an animation frame.
-    *   `Select`: Selects an object in the scene.
-    *   `execute`: Executes a command on the frontend, such as adding a new object.
+## 3. React Application Architecture
 
-## 7. Development Workflow
+* **Tooling**: Vite, React 18, modern JSX, ESLint. TypeScript can be introduced feature-by-feature when the APIs stabilise.
+* **3D Rendering**: [`three`](https://threejs.org/) with [`@react-three/fiber`](https://docs.pmnd.rs/react-three-fiber/getting-started/introduction) to manage the scene declaratively and keep React in control of the render lifecycle.
+* **State Management**: [`zustand`](https://github.com/pmndrs/zustand) for simple, composable state slices (connection status, scene graph metadata, playback state).
+* **Data Fetching**: Native `fetch` for REST-style endpoints; lightweight helpers can wrap the existing Jetty REST APIs when needed.
+* **Code Organisation**:
+  * `src/app/` – application shell, routing (later), layout primitives.
+  * `src/features/visualizer/` – visualization UI, hooks, and stores.
+  * `src/shared/` – utilities shared across features (formatters, HTTP helpers, etc.).
 
-1.  **Phase 1: Basic Setup**
-    *   Set up the React project with Vite and TypeScript.
-    *   Create the basic `ThreeCanvas` component.
-    *   Render a simple Three.js scene with a cube to verify the setup.
-2.  **Phase 2: Server Communication**
-    *   Implement the WebSocket and REST API communication logic in the new React application.
-    *   Load a simple model from the Jetty server and display it in the `ThreeCanvas` component.
-3.  **Phase 3: Feature Parity**
-    *   Implement the full functionality of the existing visualizer, including model loading, animation controls, and user interactions.
-4.  **Phase 4: Integration and Replacement**
-    *   Integrate the React application with the Jetty server.
-    *   Remove the old `Gui/opensim/threejs` directory.
+## 4. Communication & Data Flow
+
+The React app must replicate the contract used by the original `Gui/opensim/threejs/editor` frontend.
+
+### Backend Summary
+
+* **Jetty Server** (`opensim-visualizer/src/.../JettyMain.java`): serves static assets and exposes `/visEndpoint` WebSocket + REST endpoints on port 8001.
+* **WebSocket** (`VisWebSocket.java`): bidirectional JSON channel. Messages contain an `Op` field describing commands (`OpenModel`, `Frame`, `Select`, `execute`, etc.).
+* **Broadcasting** (`WebSocketDB.java`): keeps active sockets so simulation updates can be broadcast to all connected clients.
+
+### React Data Flow
+
+1. The React app boots and initialises a WebSocket connection to `/visEndpoint`.
+2. Incoming JSON payloads are parsed inside a connection hook and dispatched into the zustand store.
+3. Components subscribe to store slices to update the canvas, info panels, and UI controls.
+4. User interactions (e.g., selecting a body, changing playback) emit JSON messages that mirror the original `Op` values.
+5. REST calls (model listings, metadata) are fetched on demand and cached per component.
+
+```
++--------------------+     WebSocket/REST      +----------------------+
+| React Components   | <---------------------> | Jetty / OpenSim Core |
+|  (zustand store)   |                         |  (unchanged)         |
++--------------------+                         +----------------------+
+```
+
+## 5. Implementation Roadmap
+
+1. **Foundation**
+   * Scaffold visualizer feature folders, zustand store, and a `<VisualizerCanvas>` that mounts a Three.js scene.
+   * Surface connection status and a placeholder scene to validate the render loop.
+2. **Protocol Integration**
+   * Mirror `websocket.js` message handling inside a dedicated hook/service.
+   * Normalise message payloads in the store and expose typed selectors for React components.
+3. **Model & Scene Controls**
+   * Build components for model lists, playback controls, and selection info.
+   * Sync Three.js objects with incoming `Frame` updates.
+4. **Feature Parity & Cleanup**
+   * Incrementally port functionality from the legacy frontend.
+   * Replace the assets served by Jetty with the Vite build output once parity is acceptable.
+
+## 6. Developer Workflow
+
+* Run `npm install` / `npm run dev` inside `light-weight/` for local development.
+* Use the zustand store for any cross-component state to keep React components easy to test.
+* Keep integration points (WebSocket, REST) isolated behind hooks or services to simplify mocking during tests.
+* Document new protocols or message formats in `light-weight/docs/` (create as needed).
+
+This plan keeps the React side lean while preserving the original backend communication patterns so functionality can be ported incrementally.

--- a/light-weight/src/App.css
+++ b/light-weight/src/App.css
@@ -1,42 +1,193 @@
 #root {
-  max-width: 1280px;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #0f2a40, #08111d 70%);
+  color: #f1f5f9;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 2.5rem clamp(1.5rem, 3vw, 4rem);
+  max-width: 1200px;
+  gap: 2.5rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.app-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.app-eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+  margin: 0 0 0.35rem;
+}
+
+.app-title {
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+.app-subtitle {
+  margin: 0;
+  max-width: 48ch;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.app-main {
+  flex: 1;
+  display: flex;
+}
+
+.visualizer-page {
+  display: flex;
+  flex: 1;
+}
+
+.visualizer-layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+  width: 100%;
+}
+
+.visualizer-stage {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1rem;
+  backdrop-filter: blur(12px);
+}
+
+.visualizer-canvas {
+  width: 100%;
+  height: min(60vh, 560px);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: #0b1f33;
+  display: block;
+}
+
+.connection-panel {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  backdrop-filter: blur(12px);
+}
+
+.connection-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.25rem;
+  align-items: flex-start;
+}
+
+.connection-panel__status {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.connection-panel__status[data-status='connected'] {
+  color: #4ade80;
+}
+
+.connection-panel__status[data-status='connecting'] {
+  color: #facc15;
+}
+
+.connection-panel__status[data-status='error'] {
+  color: #f87171;
+}
+
+.connection-panel__error {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: #f87171;
+}
+
+.connection-panel__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.connection-panel__button {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(30, 41, 59, 0.85);
+  color: #e2e8f0;
+  padding: 0.55rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, background 150ms ease, border-color 150ms ease;
+}
+
+.connection-panel__button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(148, 163, 184, 0.8);
+  background: rgba(51, 65, 85, 0.9);
+}
+
+.connection-panel__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.connection-panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.connection-panel__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.connection-panel__message {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  color: rgba(226, 232, 240, 0.9);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  max-height: 320px;
+  overflow: auto;
+}
+
+@media (max-width: 960px) {
+  .visualizer-layout {
+    grid-template-columns: 1fr;
   }
-  to {
-    transform: rotate(360deg);
+
+  .connection-panel {
+    order: -1;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .visualizer-canvas {
+    height: min(50vh, 420px);
   }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/light-weight/src/App.jsx
+++ b/light-weight/src/App.jsx
@@ -1,34 +1,26 @@
-import { useState } from 'react'
-import reactLogo from '/assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import { VisualizerProvider } from './features/visualizer/state/VisualizerProvider'
+import { VisualizerPage } from './features/visualizer/components/VisualizerPage'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <VisualizerProvider>
+      <div className="app-shell">
+        <header className="app-header">
+          <div>
+            <p className="app-eyebrow">OpenSim React Prototype</p>
+            <h1 className="app-title">Lightweight Visualizer</h1>
+            <p className="app-subtitle">
+              This React prototype mirrors the communication contract used by the original OpenSim GUI while we port the
+              visualization to modern tooling.
+            </p>
+          </div>
+        </header>
+        <main className="app-main">
+          <VisualizerPage />
+        </main>
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </VisualizerProvider>
   )
 }
 

--- a/light-weight/src/features/visualizer/components/ConnectionPanel.jsx
+++ b/light-weight/src/features/visualizer/components/ConnectionPanel.jsx
@@ -1,0 +1,65 @@
+import { useMemo } from 'react'
+import { useVisualizerConnection } from '../hooks/useVisualizerConnection'
+
+const statusCopy = {
+  idle: 'Not connected',
+  connecting: 'Connecting…',
+  connected: 'Connected',
+  disconnected: 'Disconnected',
+  error: 'Connection error',
+}
+
+export function ConnectionPanel() {
+  const { status, error, connect, disconnect, send, lastMessage } = useVisualizerConnection({ autoConnect: false })
+  const messagePreview = useMemo(() => {
+    if (!lastMessage) return 'No messages received yet.'
+    try {
+      return JSON.stringify(lastMessage.parsed ?? lastMessage.raw, null, 2)
+    } catch (serializationError) {
+      return String(lastMessage.raw)
+    }
+  }, [lastMessage])
+
+  const handleConnectToggle = () => {
+    if (status === 'connected' || status === 'connecting') {
+      disconnect()
+    } else {
+      connect()
+    }
+  }
+
+  const handlePing = () => {
+    const payload = { Op: 'Ping', timestamp: Date.now() }
+    const sent = send(payload)
+    if (!sent) {
+      // eslint-disable-next-line no-console
+      console.warn('Unable to send message: socket not connected')
+    }
+  }
+
+  return (
+    <section className="connection-panel" aria-labelledby="connection-panel-title">
+      <header className="connection-panel__header">
+        <div>
+          <h2 id="connection-panel-title">Connection</h2>
+          <p className="connection-panel__status" data-status={status}>
+            {statusCopy[status] ?? status}
+          </p>
+          {error ? <p className="connection-panel__error">{error}</p> : null}
+        </div>
+        <div className="connection-panel__actions">
+          <button type="button" onClick={handleConnectToggle} className="connection-panel__button">
+            {status === 'connected' || status === 'connecting' ? 'Disconnect' : 'Connect'}
+          </button>
+          <button type="button" onClick={handlePing} className="connection-panel__button" disabled={status !== 'connected'}>
+            Send ping
+          </button>
+        </div>
+      </header>
+      <div className="connection-panel__body">
+        <h3 className="connection-panel__subtitle">Last message</h3>
+        <pre className="connection-panel__message" aria-live="polite">{messagePreview}</pre>
+      </div>
+    </section>
+  )
+}

--- a/light-weight/src/features/visualizer/components/VisualizerCanvas.jsx
+++ b/light-weight/src/features/visualizer/components/VisualizerCanvas.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react'
+import { useVisualizerState } from '../state/VisualizerProvider'
+
+export function VisualizerCanvas() {
+  const canvasRef = useRef(null)
+  const connectionStatus = useVisualizerState((state) => state.connectionStatus)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return undefined
+    const context = canvas.getContext('2d')
+    if (!context) return undefined
+
+    let animationFrameId
+
+    const handleResize = () => {
+      const rect = canvas.getBoundingClientRect()
+      const dpr = window.devicePixelRatio || 1
+      canvas.width = rect.width * dpr
+      canvas.height = rect.height * dpr
+      context.setTransform(dpr, 0, 0, dpr, 0, 0)
+    }
+
+    const render = () => {
+      const { width, height } = canvas
+      const gradient = context.createLinearGradient(0, 0, width, height)
+      gradient.addColorStop(0, '#0b1f33')
+      gradient.addColorStop(1, '#123d5d')
+
+      context.fillStyle = gradient
+      context.fillRect(0, 0, width, height)
+
+      context.fillStyle = 'rgba(255, 255, 255, 0.85)'
+      context.font = '16px system-ui'
+      context.textAlign = 'center'
+      context.fillText('Visualizer canvas placeholder', width / 2, height / 2)
+      context.font = '12px system-ui'
+      context.fillText(`Connection: ${connectionStatus}`, width / 2, height / 2 + 24)
+
+      animationFrameId = requestAnimationFrame(render)
+    }
+
+    handleResize()
+    render()
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      cancelAnimationFrame(animationFrameId)
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [connectionStatus])
+
+  return <canvas ref={canvasRef} className="visualizer-canvas" role="img" aria-label="OpenSim visualizer placeholder" />
+}

--- a/light-weight/src/features/visualizer/components/VisualizerPage.jsx
+++ b/light-weight/src/features/visualizer/components/VisualizerPage.jsx
@@ -1,0 +1,15 @@
+import { VisualizerCanvas } from './VisualizerCanvas'
+import { ConnectionPanel } from './ConnectionPanel'
+
+export function VisualizerPage() {
+  return (
+    <div className="visualizer-page">
+      <div className="visualizer-layout">
+        <div className="visualizer-stage">
+          <VisualizerCanvas />
+        </div>
+        <ConnectionPanel />
+      </div>
+    </div>
+  )
+}

--- a/light-weight/src/features/visualizer/hooks/useVisualizerConnection.js
+++ b/light-weight/src/features/visualizer/hooks/useVisualizerConnection.js
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useVisualizerDispatch, useVisualizerState } from '../state/VisualizerProvider'
+
+const DEFAULT_WS_URL = import.meta.env.VITE_VISUALIZER_WS_URL ?? 'ws://localhost:8001/visEndpoint'
+
+const createMessageId = () => (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : Math.random().toString(36).slice(2))
+
+export function useVisualizerConnection({ url = DEFAULT_WS_URL, autoConnect = true } = {}) {
+  const dispatch = useVisualizerDispatch()
+  const { connectionStatus, connectionError, lastMessage } = useVisualizerState((state) => ({
+    connectionStatus: state.connectionStatus,
+    connectionError: state.connectionError,
+    lastMessage: state.lastMessage,
+  }))
+  const socketRef = useRef(null)
+
+  const connect = useCallback(() => {
+    if (socketRef.current && (socketRef.current.readyState === WebSocket.OPEN || socketRef.current.readyState === WebSocket.CONNECTING)) {
+      return socketRef.current
+    }
+
+    dispatch({ type: 'connection:start' })
+
+    try {
+      const socket = new WebSocket(url)
+      socketRef.current = socket
+
+      socket.addEventListener('open', () => {
+        dispatch({ type: 'connection:open' })
+      })
+
+      socket.addEventListener('message', (event) => {
+        let parsed
+        try {
+          parsed = JSON.parse(event.data)
+        } catch (error) {
+          parsed = null
+        }
+        dispatch({
+          type: 'message:received',
+          payload: {
+            id: createMessageId(),
+            direction: 'inbound',
+            receivedAt: Date.now(),
+            raw: event.data,
+            parsed,
+          },
+        })
+      })
+
+      socket.addEventListener('error', (event) => {
+        dispatch({ type: 'connection:error', payload: event.message ?? 'WebSocket error' })
+      })
+
+      socket.addEventListener('close', () => {
+        dispatch({ type: 'connection:close' })
+        socketRef.current = null
+      })
+
+      return socket
+    } catch (error) {
+      dispatch({ type: 'connection:error', payload: error?.message ?? 'Unable to create WebSocket connection' })
+      return null
+    }
+  }, [dispatch, url])
+
+  const disconnect = useCallback(() => {
+    if (!socketRef.current) return
+    socketRef.current.close()
+    socketRef.current = null
+  }, [])
+
+  const send = useCallback(
+    (payload) => {
+      const socket = socketRef.current
+      if (!socket || socket.readyState !== WebSocket.OPEN) {
+        return false
+      }
+      const message = typeof payload === 'string' ? payload : JSON.stringify(payload)
+      socket.send(message)
+      dispatch({
+        type: 'message:sent',
+        payload: {
+          id: createMessageId(),
+          direction: 'outbound',
+          sentAt: Date.now(),
+          raw: message,
+          parsed: typeof payload === 'string' ? null : payload,
+        },
+      })
+      return true
+    },
+    [dispatch],
+  )
+
+  useEffect(() => {
+    if (!autoConnect) return undefined
+    const socket = connect()
+    return () => {
+      if (socket) {
+        socket.close()
+      }
+    }
+  }, [autoConnect, connect])
+
+  return {
+    status: connectionStatus,
+    error: connectionError,
+    lastMessage,
+    connect,
+    disconnect,
+    send,
+    socket: socketRef.current,
+  }
+}

--- a/light-weight/src/features/visualizer/state/VisualizerProvider.jsx
+++ b/light-weight/src/features/visualizer/state/VisualizerProvider.jsx
@@ -1,0 +1,85 @@
+import { createContext, useContext, useMemo, useReducer } from 'react'
+
+const VisualizerStateContext = createContext(undefined)
+const VisualizerDispatchContext = createContext(undefined)
+
+const initialState = {
+  connectionStatus: 'idle',
+  connectionError: null,
+  lastMessage: null,
+  messageLog: [],
+}
+
+function visualizerReducer(state, action) {
+  switch (action.type) {
+    case 'connection:start':
+      return {
+        ...state,
+        connectionStatus: 'connecting',
+        connectionError: null,
+      }
+    case 'connection:open':
+      return {
+        ...state,
+        connectionStatus: 'connected',
+      }
+    case 'connection:error':
+      return {
+        ...state,
+        connectionStatus: 'error',
+        connectionError: action.payload ?? null,
+      }
+    case 'connection:close':
+      return {
+        ...state,
+        connectionStatus: 'disconnected',
+      }
+    case 'message:received': {
+      const nextLog = [action.payload, ...state.messageLog]
+      return {
+        ...state,
+        lastMessage: action.payload,
+        messageLog: nextLog.slice(0, 20),
+      }
+    }
+    case 'message:sent': {
+      const nextLog = [action.payload, ...state.messageLog]
+      return {
+        ...state,
+        messageLog: nextLog.slice(0, 20),
+      }
+    }
+    default:
+      return state
+  }
+}
+
+export function VisualizerProvider({ children }) {
+  const [state, dispatch] = useReducer(visualizerReducer, initialState)
+  const stateValue = useMemo(() => state, [state])
+  const dispatchValue = useMemo(() => dispatch, [dispatch])
+
+  return (
+    <VisualizerStateContext.Provider value={stateValue}>
+      <VisualizerDispatchContext.Provider value={dispatchValue}>
+        {children}
+      </VisualizerDispatchContext.Provider>
+    </VisualizerStateContext.Provider>
+  )
+}
+
+export function useVisualizerState(selector) {
+  const state = useContext(VisualizerStateContext)
+  if (state === undefined) {
+    throw new Error('useVisualizerState must be used within a VisualizerProvider')
+  }
+  return selector ? selector(state) : state
+}
+
+export function useVisualizerDispatch() {
+  const dispatch = useContext(VisualizerDispatchContext)
+  if (dispatch === undefined) {
+    throw new Error('useVisualizerDispatch must be used within a VisualizerProvider')
+  }
+  return dispatch
+}

--- a/light-weight/src/index.css
+++ b/light-weight/src/index.css
@@ -1,68 +1,38 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color-scheme: dark;
+  color: #e2e8f0;
+  background-color: #0b1120;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+* {
+  box-sizing: border-box;
 }
+
+a {
+  color: inherit;
+}
+
 a:hover {
-  color: #535bf2;
+  color: inherit;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  background-color: #0b1120;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  font: inherit;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+pre {
+  font: inherit;
 }


### PR DESCRIPTION
## Summary
- refresh the integration plan with a leaner React-focused architecture and data-flow emphasis
- scaffold a lightweight visualizer shell with provider, WebSocket hook, and placeholder canvas/connection UI
- restyle the Vite app to present the new prototype layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0f20524b0832b8cc17478234f8853